### PR TITLE
アカウント登録後に設定画面に遷移するよう変更

### DIFF
--- a/OkeikoSitter/View/MainViewController.swift
+++ b/OkeikoSitter/View/MainViewController.swift
@@ -100,10 +100,7 @@ final class MainViewController: UIViewController {
     
     /// 設定ボタンがタップされたときの処理
     @objc private func didTapSettingButton(_ sender: UIButton) {
-        let settingVC = SettingViewController()
-        let navController = UINavigationController(rootViewController: settingVC)
-        navController.modalPresentationStyle = .fullScreen
-        navigationController?.present(navController, animated: true)
+        navigateToSetting()
     }
     
     /// ユーザー切り替えボタンがタップされたときの処理
@@ -132,21 +129,30 @@ final class MainViewController: UIViewController {
                 }
                 guard let user = users?.first else {
                     print("ユーザーデータなし")
+                    self?.navigateToSetting()
                     return
                 }
                 self?.updateUI(with: user)
             }
         }
     }
-
+    
     private func updateUI(with user: User) {
         userNameLabel.text = user.userName
         taskLabel.text = user.challengeTask
         dailyPointLabel.text = "\(user.challengePoint) ポイント"
-//        currentPointLabel.text = "現在　\(user.currentPoint) ポイント"
-//        bonusPointButton.setTitle("\(user.bonusPoint) ポイント", for: .normal)
+        //        currentPointLabel.text = "現在　\(user.currentPoint) ポイント"
+        //        bonusPointButton.setTitle("\(user.bonusPoint) ポイント", for: .normal)
         goalPointLabel.text = "\(user.goalPoint) ポイント"
         remainingDaysLabel.text = "\(user.challengeDay) 日"
+    }
+    
+    /// 設定画面へ遷移
+    private func navigateToSetting() {
+        let settingVC = SettingViewController()
+        let navController = UINavigationController(rootViewController: settingVC)
+        navController.modalPresentationStyle = .fullScreen
+        navigationController?.present(navController, animated: true)
     }
 }
 


### PR DESCRIPTION
## やったこと
* アカウント登録後の設定画面への遷移を実装

## 画像　（あれば）
※１つ表示したい場合
<img width="240" src="https://github.com/user-attachments/assets/5b43b867-e3bb-49de-91b8-ffc44a7c824e">

## 動作確認
- [x] アカウント登録後に設定画面に遷移し、キャンセルボタンを押しても設定画面が再度表示されるが、ログアウトボタンを押すとログイン画面に遷移すること、再度ログインすると設定画面が表示されることを確認した

