### PR TITLE
設定画面の保存処理とメイン画面の表示関係を修正

### DIFF
--- a/OkeikoSitter/View/Base.lproj/Main.storyboard
+++ b/OkeikoSitter/View/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="g7u-HK-wJ8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="g7u-HK-wJ8">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -13,7 +13,7 @@
             <objects>
                 <navigationController id="g7u-HK-wJ8" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="fVe-zX-Nbg">
-                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <rect key="frame" x="0.0" y="118" width="393" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -33,10 +33,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gey-sm-KR3">
-                                <rect key="frame" x="0.0" y="103" width="393" height="715"/>
+                                <rect key="frame" x="0.0" y="162" width="393" height="622"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Pw-Mv-FNB">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="789"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="801"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b7V-Uw-vdh">
                                                 <rect key="frame" x="0.0" y="0.0" width="393" height="70"/>
@@ -71,13 +71,13 @@
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HGZ-sC-pCP" userLabel="緑のView">
-                                                <rect key="frame" x="28" y="70" width="337" height="685"/>
+                                                <rect key="frame" x="28" y="82" width="337" height="685"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OoN-oO-zkS" userLabel="チャレンジ内容View">
                                                         <rect key="frame" x="32" y="14" width="273" height="55"/>
                                                         <subviews>
                                                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k2q-3o-EfC" userLabel="☆チャレンジ内容   （達成したらクリックしよう↓）">
-                                                                <rect key="frame" x="24.666666666666686" y="8.3333333333333428" width="224" height="38.333333333333336"/>
+                                                                <rect key="frame" x="24.666666666666686" y="8.3333333333333144" width="224" height="38.333333333333336"/>
                                                                 <string key="text">☆チャレンジ内容 
 　（達成したらクリックしよう↓）</string>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
@@ -445,7 +445,7 @@
                                             <constraint firstAttribute="trailing" secondItem="HGZ-sC-pCP" secondAttribute="trailing" constant="28" id="C4C-6O-7Nt"/>
                                             <constraint firstItem="b7V-Uw-vdh" firstAttribute="leading" secondItem="6Pw-Mv-FNB" secondAttribute="leading" id="DcN-nu-PHG"/>
                                             <constraint firstAttribute="bottom" secondItem="HGZ-sC-pCP" secondAttribute="bottom" constant="34" id="U2J-iD-ZgF"/>
-                                            <constraint firstItem="HGZ-sC-pCP" firstAttribute="top" secondItem="b7V-Uw-vdh" secondAttribute="bottom" id="a4M-7f-dzp"/>
+                                            <constraint firstItem="HGZ-sC-pCP" firstAttribute="top" secondItem="b7V-Uw-vdh" secondAttribute="bottom" constant="12" id="a4M-7f-dzp"/>
                                             <constraint firstItem="HGZ-sC-pCP" firstAttribute="leading" secondItem="6Pw-Mv-FNB" secondAttribute="leading" constant="28" id="uEa-62-eZV"/>
                                         </constraints>
                                         <userDefinedRuntimeAttributes>

--- a/OkeikoSitter/View/SettingViewController.swift
+++ b/OkeikoSitter/View/SettingViewController.swift
@@ -16,10 +16,18 @@ final class SettingViewController: UIViewController {
     private let defaultText = "ポイントを選択してください"
     /// FirebaseServiceのインスタンス
     private let firebaseService = FirebaseService.shared
-    private var challengePoint: Int?
-    private var bonusPoint: Int?
-    private var goalPoint: Int?
-    private var challengeDay: Int?
+    /// 選択した画像
+    private var selectedImage: UIImage?
+    /// 選択したチャレンジポイント
+    private var selectedChallengePoint: Int?
+    /// 選択したボーナスポイント
+    private var selectedBonusPoint: Int?
+    /// 選択した目標ポイント
+    private var selectedGoalPoint: Int?
+    /// 選択したチャレンジ日数
+    private var selectedChallengeDay: Int?
+    /// ユーザー情報
+    private var user: User?
     
     // MARK: - IBOutlets
     
@@ -48,17 +56,26 @@ final class SettingViewController: UIViewController {
     /// チャレンジ日数ボタン
     @IBOutlet private weak var challengeDaysMenuButton: PressableButton!
     
-    // MARK: - IBAction
+    // MARK: - Initializers
     
-    /// ユーザー画像ボタンをタップした
-    @IBAction private func userImageButtonTapped(_ sender: Any) {
-        presentImagePicker()
+    init(image: UIImage?, user: User?) {
+        self.selectedImage = image
+        self.user = user
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - View Life-Cycle Methods
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureTapGesture()
+        configureUI()
+        configureTextField()
+        configureTextView()
         configureBarButtonItems()
         configureChallengePointMenuButton()
         configureBonusPointMenuButton()
@@ -70,6 +87,11 @@ final class SettingViewController: UIViewController {
     
     // MARK: - IBActions
     
+    /// ユーザー画像ボタンをタップした
+    @IBAction private func userImageButtonTapped(_ sender: Any) {
+        presentImagePicker()
+    }
+    
     /// ご褒美登録ボタンをタップした
     @IBAction private func presentRegisterButtonTapped(_sender: UIButton) {
         let presentVC = PresentViewController()
@@ -80,7 +102,7 @@ final class SettingViewController: UIViewController {
     
     /// 完了ボタンをタップした
     @IBAction private func doneButtonTapped(_ sender: UIButton) {
-        saveData()
+        validateSaveData()
     }
     
     /// ログアウトボタンをタップした
@@ -89,6 +111,49 @@ final class SettingViewController: UIViewController {
     }
     
     // MARK: - Other Methods
+    
+    private func configureTapGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
+    
+    /// キーボードを閉じる
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+    
+    private func configureUI() {
+        if let user = user {
+            userNameTextField.text = user.userName
+            challengeTaskTextView.text = user.challengeTask
+            challengePointLabel.text = "\(user.challengePoint)ポイント"
+            selectedChallengePoint = user.challengePoint
+            bonusPointLabel.text = "\(user.bonusPoint)ポイント"
+            selectedBonusPoint = user.bonusPoint
+            goalPointLabel.text = "\(user.goalPoint)ポイント"
+            selectedGoalPoint = user.goalPoint
+            challengeDaysLabel.text = "\(user.challengeDay)日"
+            selectedChallengeDay = user.challengeDay
+        } else {
+            challengePointLabel.text = defaultText
+            bonusPointLabel.text = defaultText
+            goalPointLabel.text = defaultText
+            challengeDaysLabel.text = "日数を選択してください"
+        }
+        
+        if let image = selectedImage {
+            userImageView.image = image
+        }
+    }
+    
+    private func configureTextField() {
+        userNameTextField.delegate = self
+    }
+    
+    private func configureTextView() {
+        challengeTaskTextView.delegate = self
+    }
     
     private func configureBarButtonItems() {
         // 左端のキャンセルボタン（アイコン）
@@ -117,18 +182,17 @@ final class SettingViewController: UIViewController {
     }
     
     private func configureChallengePointMenuButton() {
-        challengePointLabel.text = defaultText
         let challengePointMenu = UIMenu(title: "", children: [
             UIAction(title: "1") { _ in
-                self.challengePoint = 1
+                self.selectedChallengePoint = 1
                 self.challengePointLabel.text = "\(1)ポイント"
             },
             UIAction(title: "2") { _ in
-                self.challengePoint = 2
+                self.selectedChallengePoint = 2
                 self.challengePointLabel.text = "\(2)ポイント"
             },
             UIAction(title: "3") { _ in
-                self.challengePoint = 3
+                self.selectedChallengePoint = 3
                 self.challengePointLabel.text = "\(3)ポイント"
             }
         ])
@@ -137,18 +201,17 @@ final class SettingViewController: UIViewController {
     }
     
     private func configureBonusPointMenuButton() {
-        bonusPointLabel.text = defaultText
         let bonusPointMenu = UIMenu(title: "", children: [
             UIAction(title: "3") { _ in
-                self.bonusPoint = 3
+                self.selectedBonusPoint = 3
                 self.bonusPointLabel.text = "\(3)ポイント"
             },
             UIAction(title: "5") { _ in
-                self.bonusPoint = 5
+                self.selectedBonusPoint = 5
                 self.bonusPointLabel.text = "\(5)ポイント"
             },
             UIAction(title: "10") { _ in
-                self.bonusPoint = 10
+                self.selectedBonusPoint = 10
                 self.bonusPointLabel.text = "\(10)ポイント"
             }
         ])
@@ -157,18 +220,17 @@ final class SettingViewController: UIViewController {
     }
     
     private func configureGoalPointMenuButton() {
-        goalPointLabel.text = defaultText
         let goalPointMenu = UIMenu(title: "", children: [
             UIAction(title: "30") { _ in
-                self.goalPoint = 30
+                self.selectedGoalPoint = 30
                 self.goalPointLabel.text = "\(30)ポイント"
             },
             UIAction(title: "50") { _ in
-                self.goalPoint = 50
+                self.selectedGoalPoint = 50
                 self.goalPointLabel.text = "\(50)ポイント"
             },
             UIAction(title: "100") { _ in
-                self.goalPoint = 100
+                self.selectedGoalPoint = 100
                 self.goalPointLabel.text = "\(100)ポイント"
             }
         ])
@@ -177,18 +239,17 @@ final class SettingViewController: UIViewController {
     }
     
     private func configureChallengeDaysMenuButton() {
-        challengeDaysLabel.text = "日数を選択してください"
         let challengeDaysMenu = UIMenu(title: "", children: [
             UIAction(title: "10日") { _ in
-                self.challengeDay = 10
+                self.selectedChallengeDay = 10
                 self.challengeDaysLabel.text = "\(10)日"
             },
             UIAction(title: "20日") { _ in
-                self.challengeDay = 20
+                self.selectedChallengeDay = 20
                 self.challengeDaysLabel.text = "\(20)日"
             },
             UIAction(title: "30日") { _ in
-                self.challengeDay = 30
+                self.selectedChallengeDay = 30
                 self.challengeDaysLabel.text = "\(30)日"
             }
         ])
@@ -201,8 +262,8 @@ final class SettingViewController: UIViewController {
         return ""
     }
     
-    /// データを保存する
-    private func saveData() {
+    /// データをチェックする
+    private func validateSaveData() {
         guard let user = Auth.auth().currentUser else {
             return showAlert(title: "ログインしてください")
         }
@@ -211,14 +272,14 @@ final class SettingViewController: UIViewController {
               !userName.isEmpty,
               let challengeTask = challengeTaskTextView.text,
               !challengeTask.isEmpty,
-              let challengePoint = challengePoint,
-              let bonusPoint = bonusPoint,
-              let goalPoint = goalPoint,
-              let challengeDay = challengeDay else {
+              let challengePoint = selectedChallengePoint,
+              let bonusPoint = selectedBonusPoint,
+              let goalPoint = selectedGoalPoint,
+              let challengeDay = selectedChallengeDay else {
             return showAlert(title: "設定が済んでいません", message: "全ての項目を入力してください。")
         }
         
-        let data: [String: Any] = [
+        let saveData: [String: Any] = [
             "user_id": user.uid,
             "user_name": userName,
             "challenge_task": challengeTask,
@@ -227,16 +288,11 @@ final class SettingViewController: UIViewController {
             "goal_point": goalPoint,
             "challenge_day": challengeDay
         ]
-        
-        firebaseService.save(collection: "users", data: data) { [weak self] error in
-            guard let self = self else { return }
-            if let error = error {
-                self.showAlert(title: "データの保存エラー", message: error.localizedDescription)
-            } else {
-                self.showAlert(title: "登録しました！") {
-                    self.dismiss(animated: true)
-                }
-            }
+        // 画像を保存
+        if let selectedImage = selectedImage {
+            uploadProfileImage(selectedImage, data: saveData)
+        } else {
+            self.saveData(userID: user.uid, saveData: saveData)
         }
     }
     
@@ -302,7 +358,7 @@ final class SettingViewController: UIViewController {
     }
     
     /// プロフィール画像をアップロード
-    private func uploadProfileImage(_ image: UIImage) {
+    private func uploadProfileImage(_ image: UIImage, data: [String: Any]) {
         guard let imageData = image.jpegData(compressionQuality: 0.8),
               let userID = Auth.auth().currentUser?.uid else {
             return
@@ -320,27 +376,70 @@ final class SettingViewController: UIViewController {
             }
             print("アップロード成功: \(downloadURL)")
             // Firestoreのユーザードキュメントに画像URLを保存したい場合はここで更新
-            self?.saveProfileImageURL(downloadURL.absoluteString)
+            self?.saveProfileImageURL(downloadURL.absoluteString, saveData: data)
         }
     }
     
     /// プロフィール画像を保存
-    private func saveProfileImageURL(_ urlString: String) {
+    private func saveProfileImageURL(_ urlString: String, saveData: [String: Any]) {
         guard let userID = Auth.auth().currentUser?.uid else { return }
-        let data = ["profile_image_url": urlString]
-        firebaseService.update(collection: "users", documentID: userID, data: data) { [weak self] error in
+        let image = ["profile_image_url": urlString]
+        firebaseService.update(collection: "users", documentID: userID, data: image) { [weak self] error in
+            guard let self = self else { return }
             if let error = error {
-                self?.showAlert(title: "プロフィール画像URL保存失敗", message: error.localizedDescription)
+                self.showAlert(title: "プロフィール画像URL保存失敗", message: error.localizedDescription)
+            }
+            
+            // 成功したら、他の項目の保存処理に入る
+            self.saveData(userID: userID, saveData: saveData)
+        }
+    }
+    
+    /// データを保存
+    private func saveData(userID: String, saveData: [String: Any]) {
+        self.firebaseService.save(collection: "users", documentID: userID, data: saveData) { [weak self] error in
+            guard let self = self else { return }
+            if let error = error {
+                self.showAlert(title: "データの保存エラー", message: error.localizedDescription)
+            } else {
+                print("保存データ：\(saveData)")
+                print("userID：\(userID)")
+                self.showAlert(title: "登録しました！") {
+                    self.dismiss(animated: true)
+                }
             }
         }
     }
 }
 
+// MARK: - UITextFieldDelegate
+
+extension SettingViewController: UITextFieldDelegate {
+    /// returnキーを押された時のメソッド
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        // キーボードを閉じる
+        textField.resignFirstResponder()
+        return true
+    }
+}
+
 // MARK: - UITextViewDelegate
+
 extension SettingViewController: UITextViewDelegate {
     /// チャレンジ内容UITextViewが空のときだけplaceholderLabelを表示
     func textViewDidChange(_ challengeTaskTextView: UITextView) {
         placeholderLabel.isHidden = !challengeTaskTextView.text.isEmpty
+    }
+    
+    /// returnキーを押された時のメソッド
+    func textView(_ textView: UITextView,
+                  shouldChangeTextIn range: NSRange,
+                  replacementText text: String) -> Bool {
+        if text == "\n" { // 改行が入力された場合
+            textView.resignFirstResponder() // キーボードを閉じる
+            return false // 改行はしない
+        }
+        return true
     }
 }
 
@@ -362,8 +461,7 @@ extension SettingViewController: UIImagePickerControllerDelegate, UINavigationCo
         picker.dismiss(animated: true)
         if let selectedImage = info[.originalImage] as? UIImage {
             userImageView.image = selectedImage
-            // ここでアップロードするなどの処理を行う
-            uploadProfileImage(selectedImage)
+            self.selectedImage = selectedImage
         }
     }
     

--- a/OkeikoSitter/View/SettingViewController.xib
+++ b/OkeikoSitter/View/SettingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -171,11 +171,11 @@
                                             <rect key="frame" x="70" y="0.0" width="253" height="115"/>
                                             <subviews>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Miz-NP-92I" userLabel="チャレンジ内容入力用Text View">
-                                                    <rect key="frame" x="0.0" y="0.0" width="253" height="115"/>
+                                                    <rect key="frame" x="16" y="16" width="221" height="83"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <color key="textColor" red="0.0" green="0.59999999999999998" blue="0.31764705882352939" alpha="1" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done"/>
                                                 </textView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="チャレンジ内容を入力してください" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xaV-eV-PI1" userLabel="プレースホルダーラベル">
                                                     <rect key="frame" x="6.6666666666666714" y="48" width="239.66666666666663" height="19.333333333333329"/>
@@ -189,11 +189,11 @@
                                                 <constraint firstItem="xaV-eV-PI1" firstAttribute="centerX" secondItem="fYt-cH-SLA" secondAttribute="centerX" id="DTY-JP-jfh"/>
                                                 <constraint firstAttribute="width" constant="253" id="JqR-J9-cSR"/>
                                                 <constraint firstAttribute="height" constant="115" id="XWx-Tm-HcA"/>
-                                                <constraint firstItem="Miz-NP-92I" firstAttribute="top" secondItem="fYt-cH-SLA" secondAttribute="top" id="bTn-lI-Ctn"/>
-                                                <constraint firstAttribute="trailing" secondItem="Miz-NP-92I" secondAttribute="trailing" id="mrZ-iM-fdG"/>
-                                                <constraint firstAttribute="bottom" secondItem="Miz-NP-92I" secondAttribute="bottom" id="p5d-Pn-uSq"/>
+                                                <constraint firstItem="Miz-NP-92I" firstAttribute="top" secondItem="fYt-cH-SLA" secondAttribute="top" constant="16" id="bTn-lI-Ctn"/>
+                                                <constraint firstAttribute="trailing" secondItem="Miz-NP-92I" secondAttribute="trailing" constant="16" id="mrZ-iM-fdG"/>
+                                                <constraint firstAttribute="bottom" secondItem="Miz-NP-92I" secondAttribute="bottom" constant="16" id="p5d-Pn-uSq"/>
                                                 <constraint firstItem="xaV-eV-PI1" firstAttribute="centerY" secondItem="fYt-cH-SLA" secondAttribute="centerY" id="uvG-iW-mEa"/>
-                                                <constraint firstItem="Miz-NP-92I" firstAttribute="leading" secondItem="fYt-cH-SLA" secondAttribute="leading" id="zmg-Sj-BEs"/>
+                                                <constraint firstItem="Miz-NP-92I" firstAttribute="leading" secondItem="fYt-cH-SLA" secondAttribute="leading" constant="16" id="zmg-Sj-BEs"/>
                                             </constraints>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -504,7 +504,7 @@
                                             </constraints>
                                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <state key="normal" title="Button"/>
-                                            <buttonConfiguration key="configuration" style="plain" image="ic_check" title=" 完了"/>
+                                            <buttonConfiguration key="configuration" style="plain" image="ic_check" title=" 保存"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                                     <integer key="value" value="8"/>


### PR DESCRIPTION
## やったこと
* 設定画面の保存処理を修正
* メイン画面から設定画面に遷移する際に値を渡す
* メイン画面の表示を修正
* 設定画面でキーボードが閉じるよう修正

## 画像　（あれば）
* 画像と緑ビューの間を空けた
* チャレンジ内容ボタンで「＋○ポイント」に修正
* ボーナスポイントボタンで「ボーナス＋○ポイント」に修正
<img width="240" src="https://github.com/user-attachments/assets/d847ecf8-ec76-4a0a-9afd-1c089a21a489">

## 動作確認
- [x] 設定画面で保存ができることを確認した
- [x] メイン画面に反映されることを確認した
- [x] 設定画面に遷移して登録情報が反映されることを確認した
